### PR TITLE
Added correct CFD values

### DIFF
--- a/Converter.cc
+++ b/Converter.cc
@@ -273,7 +273,21 @@ bool Converter::Run() {
 								case 8030://red
 								case 8040://white
 								case 8050://yellow
+									{
 									mnemonic = Form("DSC%02dXN00X", fDetNumber);
+									// calculate cfd (0 - 8 ns) in 1/256 ns
+									int cfd = fTime*256e9;
+									cfd = cfd%1024;//1024 = 256 steps for 0 - 8 ns
+									// calculate remainder between 8 ns timestamp and 10 ns timestamp
+									int rem = fTime*1e9;
+									rem = rem%40;
+									if(rem < 8)       rem = 0;
+									else if(rem < 16) rem = 8;
+									else if(rem < 24) rem = 6;
+									else if(rem < 32) rem = 4;
+									else              rem = 2;
+									fFragments[address].SetCfd((rem << 22) | cfd);
+									}
 									break;
 								default: 
 									std::cerr<<"Sorry, unknown system ID "<<fSystemID<<std::endl;

--- a/Converter.hh
+++ b/Converter.hh
@@ -29,6 +29,7 @@ public:
 	bool Run();
 
 private:
+	int  Cfd(TMnemonic::EDigitizer);
 	bool AboveThreshold(double, int);
 	bool InsideTimeWindow();
 	bool DescantNeutronDiscrimination();

--- a/Makefile
+++ b/Makefile
@@ -85,4 +85,4 @@ tar:
 # -------------------- clean --------------------
 
 clean:
-	rm  -f $(NAME) lib$(NAME).so *.o $(NAME)Dictionary.cc $(NAME)Dictionary.h
+	@rm  -f $(NAME) lib$(NAME).so *.o $(NAME)Dictionary.cc $(NAME)Dictionary.h


### PR DESCRIPTION
So far we've only set the timestamp of a fragment, not its CFD value. This meant our timing resolution was limited to 10 ns.
I've added a function Converter::Cfd which takes the digitizer type as an argument and uses the simulation time to calculate the right CFD value for the fragment.
Right now all detectors use the GRIF-16 format, except for  DESCANT which uses the GRIF-4G format.
This means DESCANT timing can be done in 1/256 ns units, all others in 1/1.6 ns units.